### PR TITLE
Restore compatibility with 1.12 and 1.12.1

### DIFF
--- a/src/main/java/hellfirepvp/modularmachinery/ModularMachinery.java
+++ b/src/main/java/hellfirepvp/modularmachinery/ModularMachinery.java
@@ -39,7 +39,7 @@ import java.io.File;
  * Date: 26.06.2017 / 20:26
  */
 @Mod(modid = ModularMachinery.MODID, name = ModularMachinery.NAME, version = ModularMachinery.VERSION,
-dependencies = "required-after:forge@[14.21.0.2371,);after:crafttweaker@[4.0.4,)")
+acceptedMinecraftVersions = "[1.12, 1.13)", dependencies = "required-after:forge@[14.21.0.2371,);after:crafttweaker@[4.0.4,)")
 public class ModularMachinery {
 
     public static final String MODID = "modularmachinery";


### PR DESCRIPTION
This appears to have been lost in commit b71692a.