### PR TITLE
Better internationalization support

### DIFF
--- a/src/main/java/hellfirepvp/modularmachinery/common/crafting/RecipeLoader.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/crafting/RecipeLoader.java
@@ -19,6 +19,7 @@ import net.minecraft.util.JsonUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -69,7 +70,7 @@ public class RecipeLoader {
         List<MachineRecipe> loadedRecipes = Lists.newArrayList();
         for (File f : candidates.get(FileType.RECIPE)) {
             currentlyReadingPath = f.getPath();
-            try (InputStreamReader isr = new InputStreamReader(new FileInputStream(f))) {
+            try (InputStreamReader isr = new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8)) {
                 MachineRecipe.MachineRecipeContainer container = JsonUtils.fromJson(GSON, isr, MachineRecipe.MachineRecipeContainer.class);
                 loadedRecipes.addAll(container.getRecipes());
             } catch (Exception exc) {

--- a/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
@@ -31,6 +31,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StringUtils;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
@@ -87,7 +88,12 @@ public class DynamicMachine {
     }
 
     public String getLocalizedName() {
-        return localizedName;
+        String localizationKey = registryName.getResourceDomain() + "." + registryName.getResourcePath();
+        if (I18n.canTranslate(localizationKey)) {
+            return I18n.translateToLocal(localizationKey);
+        } else {
+            return localizedName;
+        }
     }
 
     public int getMachineColor() {

--- a/src/main/java/hellfirepvp/modularmachinery/common/machine/MachineLoader.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/machine/MachineLoader.java
@@ -20,6 +20,7 @@ import net.minecraft.util.JsonUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -73,7 +74,7 @@ public class MachineLoader {
     public static List<DynamicMachine> loadMachines(List<File> machineCandidates) {
         List<DynamicMachine> loadedMachines = Lists.newArrayList();
         for (File f : machineCandidates) {
-            try (InputStreamReader isr = new InputStreamReader(new FileInputStream(f))) {
+            try (InputStreamReader isr = new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8)) {
                 loadedMachines.add(JsonUtils.fromJson(GSON, isr, DynamicMachine.class));
             } catch (Exception exc) {
                 failedAttempts.put(f.getPath(), exc);


### PR DESCRIPTION
This pull request consists two parts:

  1. Enforce UTF-8 charset to ensure cross-platform compatibility.
      Switch the constructor of `InputStreamReader` to the one with explicit `Charset` parameter. Relying on system default charset (i.e. using the constructor without `Charset` parameter; [according to javadoc](https://docs.oracle.com/javase/8/docs/api/java/io/InputStreamReader.html#InputStreamReader-java.io.InputStream-), it implies using system default charset) can lead to issue on different operating systems. Example would be a dynamic machine definition that is written under Windows may lead to scribbled display name on macOS/Linux distro, if contains non-standard Latin alphabets (for example, those with diacritics, like ä, é, ñ), or even non-Latin scripts (for instances, Cyrillic and Chinese).
  2. Multilingual support for machine display name.
      The getter of `localizedName` is changed, so that it try to find translation of key `modularmachinary.${machine_registry_name}` first, and if failed, use the pre-defined `localizedName` instead. This may be useful in situations like modpack localization, where one may want to provide translation of machine names without touching the original machine definition file(s). In fact, the motivation of this pull request is @TartaricAcid's encountering trouble while translating contents of SevTech: Ages.

Comments are welcome.