### PR TITLE
Fix localization not really working in DynamicMachine

### DIFF
--- a/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
+++ b/src/main/java/hellfirepvp/modularmachinery/common/machine/DynamicMachine.java
@@ -92,11 +92,9 @@ public class DynamicMachine {
 
     @SideOnly(Side.CLIENT)
     public String getLocalizedName() {
-        if (localizedName != null) {
-            return localizedName;
-        }
         String localizationKey = registryName.getResourceDomain() + "." + registryName.getResourcePath();
-        return I18n.hasKey(localizationKey) ? I18n.format(localizationKey) : localizationKey;
+        return I18n.hasKey(localizationKey) ? I18n.format(localizationKey) : 
+                localizedName != null ? localizedName : localizationKey;
     }
 
     public int getMachineColor() {


### PR DESCRIPTION
```localizedName``` will never be ```null``` when calling ```DynamicMachine.MachineDeserializer.deserialize``` to deserialize a machine from JSON file. So localization didn't work here. ```getLocalizedName``` will always return the ```localizedName``` in JSON file.
Should first search ```localizationKey``` in ```I18n``` and then use ```localizedName``` in JSON file for localized name.